### PR TITLE
Support null values

### DIFF
--- a/lib/src/analyzer/analyzer.dart
+++ b/lib/src/analyzer/analyzer.dart
@@ -161,7 +161,7 @@ class JsonAnalyzer {
       token.type == TokenType.DOUBLE ||
       token.type == TokenType.STRING ||
       (token.type == TokenType.IDENTIFIER &&
-          ('true' == token.toString() || 'false' == token.toString()));
+          ('true' == token.toString() || 'false' == token.toString() || 'null' == token.toString()));
 
   bool _isObjectStartToken(Token token) => token.lexeme == '{';
 

--- a/lib/src/json_editor_model.dart
+++ b/lib/src/json_editor_model.dart
@@ -47,6 +47,9 @@ class JsonElement {
           (tokens.lexeme == 'true' || tokens.lexeme == 'false')) {
         value = tokens.lexeme == 'true';
         valueType = JsonElementValueType.bool;
+     } else if (tokens.type == TokenType.IDENTIFIER && tokens.lexeme == 'null') {
+        value = 'null';
+        valueType = JsonElementValueType.nullValue;
       } else if (tokens.lexeme == '{') {
         value = [];
         valueType = JsonElementValueType.map;
@@ -97,6 +100,8 @@ class JsonElement {
       valueType = JsonElementValueType.numeric;
     } else if (valueTypeStr == JsonElementValueType.bool.toString()) {
       valueType = JsonElementValueType.bool;
+    } else if (valueTypeStr == JsonElementValueType.nullValue.toString()) {
+      valueType = JsonElementValueType.nullValue;
     } else if (valueTypeStr == JsonElementValueType.map.toString()) {
       valueType = JsonElementValueType.map;
       elementValue =
@@ -269,4 +274,4 @@ class JsonElement {
   }
 }
 
-enum JsonElementValueType { numeric, string, bool, array, map }
+enum JsonElementValueType { numeric, string, bool, array, map, nullValue }

--- a/lib/src/rich_text_field/highlight_theme/json_theme.dart
+++ b/lib/src/rich_text_field/highlight_theme/json_theme.dart
@@ -17,6 +17,7 @@ class JsonTheme implements HighlightTheme {
     TextStyle? keyStyle,
     TextStyle? commentStyle,
     TextStyle? errorStyle,
+    TextStyle? nullStyle,
   })  : defaultStyle = defaultStyle ??
             TextStyle(color: Colors.blueGrey.shade900, fontSize: 14),
         bracketStyle = bracketStyle ??
@@ -37,7 +38,9 @@ class JsonTheme implements HighlightTheme {
                 fontSize: 14,
                 fontWeight: FontWeight.bold,
                 fontStyle: FontStyle.italic,
-                decoration: TextDecoration.underline);
+                decoration: TextDecoration.underline),
+        nullStyle = nullStyle ??
+            TextStyle(color: Colors.red.shade600, fontSize: 14);
 
   factory JsonTheme.light() => JsonTheme(
       defaultStyle: TextStyle(color: Colors.blueGrey.shade900, fontSize: 14),
@@ -52,7 +55,8 @@ class JsonTheme implements HighlightTheme {
           fontSize: 14,
           fontWeight: FontWeight.bold,
           fontStyle: FontStyle.italic,
-          decoration: TextDecoration.underline));
+          decoration: TextDecoration.underline),
+      nullStyle: TextStyle(color: Colors.red.shade600, fontSize: 14));
 
   factory JsonTheme.dark() => JsonTheme(
       defaultStyle: TextStyle(color: Colors.white, fontSize: 14),
@@ -67,7 +71,8 @@ class JsonTheme implements HighlightTheme {
           fontSize: 14,
           fontWeight: FontWeight.bold,
           fontStyle: FontStyle.italic,
-          decoration: TextDecoration.underline));
+          decoration: TextDecoration.underline),
+      nullStyle: TextStyle(color: Colors.red.shade600, fontSize: 14));
 
   @override
   final TextStyle defaultStyle;
@@ -78,6 +83,7 @@ class JsonTheme implements HighlightTheme {
   final TextStyle keyStyle;
   final TextStyle commentStyle;
   final TextStyle errorStyle;
+  final TextStyle nullStyle;
 
   final _config = HighlightConfig(brackets: [
     Pair(open: '{', close: '}'),
@@ -108,6 +114,7 @@ class JsonTheme implements HighlightTheme {
         HighlightDataType.key: keyStyle,
         HighlightDataType.comment: commentStyle,
         HighlightDataType.error: errorStyle,
+        HighlightDataType.nullValue: nullStyle,
       };
 
   @override
@@ -122,6 +129,7 @@ class JsonTheme implements HighlightTheme {
     TextStyle? keyStyle,
     TextStyle? commentStyle,
     TextStyle? errorStyle,
+    TextStyle? nullStyle,
   }) =>
       JsonTheme(
           defaultStyle: defaultStyle ?? this.defaultStyle,
@@ -131,5 +139,6 @@ class JsonTheme implements HighlightTheme {
           boolStyle: boolStyle ?? this.boolStyle,
           keyStyle: keyStyle ?? this.keyStyle,
           commentStyle: commentStyle ?? this.commentStyle,
-          errorStyle: errorStyle ?? this.errorStyle);
+          errorStyle: errorStyle ?? this.errorStyle,
+          nullStyle: nullStyle ?? this.nullStyle);
 }

--- a/lib/src/rich_text_field/highlight_theme/theme.dart
+++ b/lib/src/rich_text_field/highlight_theme/theme.dart
@@ -17,4 +17,4 @@ abstract class HighlightTheme {
   TextStyle get defaultStyle;
 }
 
-enum HighlightDataType { int, double, string, bool, key, comment, error }
+enum HighlightDataType { int, double, string, bool, key, comment, error, nullValue }

--- a/lib/src/rich_text_field/rich_text_editing_controller.dart
+++ b/lib/src/rich_text_field/rich_text_editing_controller.dart
@@ -58,6 +58,10 @@ class RichTextEditingController extends TextEditingController {
           span = TextSpan(
               text: tokens.lexeme,
               style: jsonTheme.typeStyle[HighlightDataType.bool]);
+        } else if (tokens.lexeme == 'null') {
+          span = TextSpan(
+              text: tokens.lexeme,
+              style: jsonTheme.typeStyle[HighlightDataType.nullValue]);
         } else if (tokens.type == TokenType.INT) {
           span = TextSpan(
               text: tokens.lexeme,

--- a/test/json_editor_test.dart
+++ b/test/json_editor_test.dart
@@ -39,20 +39,20 @@ void main() {
   group('Anylyzer', () {
     test('Anlyze 1', () {
       var error = JsonAnalyzer().analyze(
-          '{"name": "you", "age": 23, "child": true, "obj": { "serialNo": [ 1, 2, 3]}}');
+          '{"name": "you", "age": 23, "child": true, "obj": { "serialNo": [ 1, 2, 3]}, "null": null}');
       expect(error, null);
     });
 
     test('Anlyze 2', () {
       var error = JsonAnalyzer().analyze(
-          '{\n   "name": "you""name":, "age": 23, "child": true, "obj": { "serialNo": [ 1, 2, 3]}}');
+          '{\n   "name": "you""name":, "age": 23, "child": true, "obj": { "serialNo": [ 1, 2, 3]}}, null: null');
       var passed = error != null;
       expect(passed, true);
     });
 
     test('Anlyze 2', () {
       var error = JsonAnalyzer().analyze(
-          '{\n   "name": "you", "age": 23, "child": true, "obj": { "serialNo": [ 1, 2, 3]}');
+          '{\n   "name": "you", "age": 23, "child": true, "obj": { "serialNo": [ 1, 2, 3],"null":null}');
       var passed = error != null;
       expect(passed, true);
     });


### PR DESCRIPTION
As mentioned in #12, `null` is currently not supported as a valid value, even though it is part of the JSON spec and present in many objects, which are currently rejected as invalid JSON.

This PR adds support for `null` value types in this library when serialising, deserialising, parsing and highlighting JSON.